### PR TITLE
Fix Inno Setup compiler not found error in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,10 @@ jobs:
         with:
           vsversion: 2022
 
+      - name: Install Inno Setup (Windows)
+        if: runner.os == 'Windows'
+        run: choco install innosetup
+
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           submodules: true


### PR DESCRIPTION
The error was caused by the migration of the windows-latest GitHub Actions runner to the Windows Server 2025 image, where Inno Setup was no longer included by default:
https://github.com/actions/runner-images/blob/main/images/windows/Windows2025-Readme.md