### PR TITLE
Remove manual Inno Setup installation step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,10 +58,6 @@ jobs:
         with:
           vsversion: 2022
 
-      - name: Install Inno Setup (Windows)
-        if: runner.os == 'Windows'
-        run: choco install innosetup
-
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           submodules: true


### PR DESCRIPTION
Inno Setup is now preinstalled on Windows Server 2025 runners as of [this image update](https://github.com/actions/runner-images/releases/tag/win25%2F20251014.59).
The manual installation step has been removed accordingly.